### PR TITLE
Dockerize server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ node_modules
 # ds store
 .DS_Store
 
+# vim
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+ FROM python:3
+
+ ENV PYTHONUNBUFFERED 1
+
+ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
+    rm ~/miniconda.sh
+ COPY . /code/
+
+ RUN /opt/conda/bin/conda create --name dev --file /code/server/config/homelessness-env.txt
+
+ ENV PATH /opt/conda/bin:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  db:
+    image: postgres
+  web:
+    build: .
+    command: python3 manage.py runserver 0.0.0.0:8000
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db


### PR DESCRIPTION
Getting an error when running `conda create --name dev --file /code/server/config/homelessness-env.txt`
```
Step 5/6 : RUN /opt/conda/bin/conda create --name dev --file /code/server/config/homelessness-env.txt
 ---> Running in 9c1b95abfcdc
vs2015_runtime 100% |###############################| Time: 0:00:00   9.03 MB/s
jinja2-time-0. 100% |###############################| Time: 0:00:00   9.40 MB/s
pysocks-1.6.8- 100% |###############################| Time: 0:00:00   5.29 MB/s
urllib3-1.22-p 100% |###############################| Time: 0:00:00   4.33 MB/s
python-3.5.2-0 100% |###############################| Time: 0:00:02  11.18 MB/s
django-environ 100% |###############################| Time: 0:00:00   4.67 MB/s
poyo-0.4.1-py3 100% |###############################| Time: 0:00:00   8.20 MB/s
asn1crypto-0.2 100% |###############################| Time: 0:00:00   8.05 MB/s
ca-certificate 100% |###############################| Time: 0:00:00   8.24 MB/s
setuptools-38. 100% |###############################| Time: 0:00:00   9.59 MB/s
arrow-0.10.0-p 100% |###############################| Time: 0:00:00  14.10 MB/s
pyopenssl-17.2 100% |###############################| Time: 0:00:00   9.09 MB/s
openssl-1.0.2n 100% |###############################| Time: 0:00:00  10.42 MB/s
markupsafe-1.0 100% |###############################| Time: 0:00:00  26.65 MB/s
cryptography-2 100% |###############################| Time: 0:00:00   9.04 MB/s
krb5-1.14.2-h6 100% |###############################| Time: 0:00:00   6.50 MB/s
tk-8.6.7-hcb92 100% |###############################| Time: 0:00:00  10.71 MB/s
pycparser-2.18 100% |###############################| Time: 0:00:00   7.03 MB/s
pytz-2017.3-py 100% |###############################| Time: 0:00:00  12.14 MB/s
future-0.16.0- 100% |###############################| Time: 0:00:00   9.58 MB/s
certifi-2017.1 100% |###############################| Time: 0:00:00  12.85 MB/s
six-1.11.0-py3 100% |###############################| Time: 0:00:00  22.19 MB/s
chardet-3.0.4- 100% |###############################| Time: 0:00:00  11.06 MB/s
cffi-1.11.2-py 100% |###############################| Time: 0:00:00  10.25 MB/s
win_inet_pton- 100% |###############################| Time: 0:00:00   6.89 MB/s
jinja2-2.10-py 100% |###############################| Time: 0:00:00  10.71 MB/s
python-dateuti 100% |###############################| Time: 0:00:00  11.92 MB/s
idna-2.6-py35_ 100% |###############################| Time: 0:00:00  15.39 MB/s
pip-9.0.1-py35 100% |###############################| Time: 0:00:00  11.94 MB/s
click-6.7-py_1 100% |###############################| Time: 0:00:00   7.88 MB/s
cookiecutter-1 100% |###############################| Time: 0:00:00   9.71 MB/s
libpq-9.6.6-hf 100% |###############################| Time: 0:00:00  16.92 MB/s
wincertstore-0 100% |###############################| Time: 0:00:00  20.79 MB/s
vc-14-h0510ff6 100% |###############################| Time: 0:00:00   5.29 MB/s
whichcraft-0.4 100% |###############################| Time: 0:00:00  10.60 MB/s
binaryornot-0. 100% |###############################| Time: 0:00:00  10.52 MB/s
wheel-0.30.0-p 100% |###############################| Time: 0:00:00  13.00 MB/s
psycopg2-2.7.3 100% |###############################| Time: 0:00:00  11.80 MB/s
django-1.11.8- 100% |###############################| Time: 0:00:00  10.45 MB/s
requests-2.18. 100% |###############################| Time: 0:00:00   5.03 MB/s
ERROR conda.core.link:_execute_actions(337): An error occurred while installing package 'conda-forge::click-6.7-py_1'.
OSError(2, 'No such file or directory')
Attempting to roll back.


OSError(2, 'No such file or directory')
```