### PR TITLE
Updating Docker container and services to run backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
- FROM python:3
+FROM python:3.6
 
- ENV PYTHONUNBUFFERED 1
+WORKDIR /app
 
- RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
-    wget --quiet https://repo.continuum.io/miniconda/Miniconda2-4.3.27-Linux-x86_64.sh -O ~/miniconda.sh && \
-    /bin/bash ~/miniconda.sh -b -p /opt/conda && \
-    rm ~/miniconda.sh
- COPY . /code/
+ADD /server/config/requirements.txt /app/config/requirements.txt
 
- RUN /opt/conda/bin/conda create --name dev --file /code/server/config/homelessness-env.txt
+RUN pip install -r config/requirements.txt
 
- ENV PATH /opt/conda/bin:$PATH
+ADD . /app
+
+EXPOSE 8000
+
+cmd ["python", "server/manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,21 @@ version: '3'
 
 services:
   db:
-    image: postgres
+    image: postgres:9.6
+    volumes:
+      - pgdata:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
   web:
     build: .
-    command: python3 manage.py runserver 0.0.0.0:8000
+    image: homelessnessapp
     volumes:
-      - .:/usr/src/app
+      - .:/app
     ports:
       - "8000:8000"
     depends_on:
       - db
+
+volumes:
+  pgdata:

--- a/server/config/requirements.txt
+++ b/server/config/requirements.txt
@@ -1,0 +1,16 @@
+django-environ==0.4.4
+django==1.11.8
+numpy==1.14.0
+pandas==0.22.0
+pip==9.0.1
+psycopg2==2.7.3.2
+django-allauth==0.35.0
+django-coverage-plugin==1.5.0
+django-crispy-forms==1.7.0
+django-debug-toolbar==1.9.1
+django-extensions==1.9.9
+django-model-utils==3.1.1
+django-redis==4.8.0
+django-reset-migrations==0.3.1
+django-test-plus==1.0.22
+djangorestframework==3.7.7

--- a/server/config/settings/base.py
+++ b/server/config/settings/base.py
@@ -123,11 +123,10 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'homelessness',
-        'USER': 'homeuser',
-        'PASSWORD': 'abcdefg',
-        'HOST': 'localhost',
-        'PORT': '5432',
+        'NAME': 'postgres',
+        'USER': 'postgres',
+        'HOST': 'db',
+        'PORT': 5432,
     }
 }
 


### PR DESCRIPTION
Updated repository to build a docker container.

Steps to run in terminal/shell :

1. Create a Docker image
```
docker build -t homelessnessapp .
```
2. Start the application
```
docker-compose up
```
3. In a separate terminal tab, run the migrations to the database
```
docker-compose exec web python server/manage.py migrate
```

After running these steps, you can access the server application at localhost:8000. 

I made a separate `requirements.txt` with only the dependencies required to run the server application. I was able to create an Anaconda image that installed the env yaml file in the repo, but majority of the conda libraries were unable to be found, so it was easier/quicker to use pip.  You can update the requirements.txt with additional libraries and then run `docker-compose up --build` as a shortcut to rebuild the image and run the app.